### PR TITLE
Fixes styles loading when app consumes an addon

### DIFF
--- a/apps/three-eighteen/index.js
+++ b/apps/three-eighteen/index.js
@@ -7,6 +7,10 @@ module.exports = {
   treeForAddon() {
     var tree = this._super(...arguments);
 
-    return staticPostcssAddonTree(tree, this.app.project);
+    return staticPostcssAddonTree(tree, {
+      addonName: 'three-eighteen',
+      addonFolder: __dirname,
+      project: this.app.project
+    });
   }
 };

--- a/apps/three-seventeen/index.js
+++ b/apps/three-seventeen/index.js
@@ -7,6 +7,10 @@ module.exports = {
   treeForAddon() {
     var tree = this._super(...arguments);
 
-    return staticPostcssAddonTree(tree, this.app.project);
+    return staticPostcssAddonTree(tree, {
+      addonName: 'three-seventeen',
+      addonFolder: __dirname,
+      project: this.app.project
+    });
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,31 +6,49 @@ const CssImport = require('postcss-import');
 const PresetEnv = require('postcss-preset-env');
 const broccoliPostCSS = require('broccoli-postcss')
 const mergeTrees = require('broccoli-merge-trees');
+const get = require('lodash.get');
 
-module.exports = function (tree, project, postCssPlugins = [
-  PresetEnv({
-    stage: 3,
-    features: { 'nesting-rules': true },
-    overrideBrowserslist: [
-      'last 1 Chrome versions',
-      'last 1 Firefox versions',
-      'last 1 Safari versions',
-      'ie 11',
-    ],
-  })
-]) {
+module.exports = function (tree, options) {
+  if(!options.addonName) {
+    throw new Error('addonName must be provided to static-postcss-addon-tree options')
+  }
+
+  if(!options.addonFolder) {
+    throw new Error('addonFolder must be provided to static-postcss-addon-tree options')
+  }
+
+  if(!options.project) {
+    throw new Error('project must be provided to static-postcss-addon-tree options')
+  }
+
+  let postCssPlugins = options.postCssPlugins;
+  
+  if(!postCssPlugins) {
+    // I don't know exactly why targets is private so I am using `get()` to make
+    // sure that it isn't missing
+    let overrideBrowserslist = get(this, 'app.project._targets.browsers');
+    
+    postCssPlugins = [
+      PresetEnv({
+        stage: 3,
+        features: { 'nesting-rules': true },
+        overrideBrowserslist,
+      })
+    ]
+  }
+
   const addonWithoutStyles = funnel(tree, {
     exclude: ['**/*.css'],
   });
 
   const addonStyles = funnel(tree, {
-    include: [`**/${project.name()}.css`],
+    include: [`**/${options.addonName}.css`],
   });
 
   let processedStyles = broccoliPostCSS(addonStyles, {
     plugins: [
       CssImport({
-        path: join(project.root, 'addon', 'styles'),
+        path: join(options.addonFolder, 'addon', 'styles'),
       }),
       ...postCssPlugins
     ]});


### PR DESCRIPTION
- there was an issue that prevented loading of styles when an app consumed an addon that used static-postcss-addon-tree
- this fixes this by correcting the project name and directory used and makes them arguments to be supplied when calling static-postcss-addon-tree
Closes #1 